### PR TITLE
Handling read/write of I/O port address spaces could be problematic f…

### DIFF
--- a/src/kernel/drivers/net/can/sja1000/adv_pci.c
+++ b/src/kernel/drivers/net/can/sja1000/adv_pci.c
@@ -45,13 +45,13 @@ MODULE_LICENSE("GPL v2");
 #define MAX_NO_OF_CHANNELS        4 /* max no of channels on a single card */
 
 struct adv_pci {
-	struct pci_dev *pci_dev;
-	struct net_device *slave_dev[MAX_NO_OF_CHANNELS];
-	int no_channels;
+    struct pci_dev *pci_dev;
+    struct net_device *slave_dev[MAX_NO_OF_CHANNELS];
+    int no_channels;
 };
 
 struct adv_board_data {
-	int reg_shift;
+    int reg_shift;
 };
 
 #define ADV_PCI_CAN_CLOCK      (16000000 / 2)
@@ -72,136 +72,136 @@ struct adv_board_data {
 #define ADV_PCI_VENDOR_ID         0x13fe
 
 static const struct pci_device_id adv_pci_tbl[] = {
-	{ADV_PCI_VENDOR_ID, 0x1680, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0x3680, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0x2052, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0x1681, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc001, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc002, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc004, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc101, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc102, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc104, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc201, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc202, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc204, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc301, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc302, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0xc304, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0x00c5, PCI_ANY_ID, PCI_ANY_ID,},
-	{ADV_PCI_VENDOR_ID, 0x00d7, PCI_ANY_ID, PCI_ANY_ID,},
-	{0,}
+    {ADV_PCI_VENDOR_ID, 0x1680, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0x3680, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0x2052, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0x1681, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc001, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc002, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc004, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc101, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc102, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc104, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc201, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc202, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc204, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc301, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc302, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0xc304, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0x00c5, PCI_ANY_ID, PCI_ANY_ID,},
+    {ADV_PCI_VENDOR_ID, 0x00d7, PCI_ANY_ID, PCI_ANY_ID,},
+    {0,}
 };
 
 MODULE_DEVICE_TABLE(pci, adv_pci_tbl);
 
 static u8 adv_pci_read_reg(const struct sja1000_priv *priv, int port)
 {
-	struct adv_board_data *board_data = priv->priv;
+    struct adv_board_data *board_data = priv->priv;
 
-	return ioread8(priv->reg_base + (port << board_data->reg_shift));
+    return ioread8(priv->reg_base + (port << board_data->reg_shift));
 }
 
 static void adv_pci_write_reg(const struct sja1000_priv *priv,
-				int port, u8 val)
+                int port, u8 val)
 {
-	struct adv_board_data *board_data = priv->priv;
+    struct adv_board_data *board_data = priv->priv;
 
-	iowrite8(val, priv->reg_base + (port << board_data->reg_shift));
+    iowrite8(val, priv->reg_base + (port << board_data->reg_shift));
 }
 
 static int adv_pci_device_support_check(const struct pci_dev *pdev)
 {
-	int err;
-	const struct pci_device_id *ids;
+    int err;
+    const struct pci_device_id *ids;
 
-	ids = adv_pci_tbl;
-	err = -ENOMEM;
+    ids = adv_pci_tbl;
+    err = -ENOMEM;
 
-	if (ids) {
-		while (ids->vendor || ids->subvendor || ids->class_mask) {
-			if (ids->device == pdev->device) {
-				err = 0;
-				break;
-			}
-			ids++;
-		}
-	}
+    if (ids) {
+        while (ids->vendor || ids->subvendor || ids->class_mask) {
+            if (ids->device == pdev->device) {
+                err = 0;
+                break;
+            }
+            ids++;
+        }
+    }
 
-	return err;
+    return err;
 }
 
 static int number_of_sja1000_chips(const struct pci_dev *pdev)
 {
-	int no_of_chips = 0;
+    int no_of_chips = 0;
 
-	switch (pdev->device) {
-	case 0x1680:
-	case 0x2052:
-	case 0x00c5:
-	case 0x00d7:
-		no_of_chips = 2;
-		break;
-	case 0x1681:
-		no_of_chips = 1;
-		break;
-	default:
-		no_of_chips = pdev->device & 0x7;
-		break;
-	}
+    switch (pdev->device) {
+    case 0x1680:
+    case 0x2052:
+    case 0x00c5:
+    case 0x00d7:
+        no_of_chips = 2;
+        break;
+    case 0x1681:
+        no_of_chips = 1;
+        break;
+    default:
+        no_of_chips = pdev->device & 0x7;
+        break;
+    }
 
-	return no_of_chips;
+    return no_of_chips;
 }
 
 static int adv_pci_bar_no(const struct pci_dev *pdev)
 {
-	int bar_no = 0;
+    int bar_no = 0;
 
-	switch (pdev->device) {
-	case 0x1680:
-	case 0x2052:
-	case 0x1681:
-		bar_no = 2;
-		break;
-	default:
-		break;
-	}
+    switch (pdev->device) {
+    case 0x1680:
+    case 0x2052:
+    case 0x1681:
+        bar_no = 2;
+        break;
+    default:
+        break;
+    }
 
-	return bar_no;
+    return bar_no;
 }
 
 static int adv_pci_bar_offset(const struct pci_dev *pdev)
 {
-	int bar_offset = 0x100;
+    int bar_offset = 0x100;
 
-	switch (pdev->device) {
-	case 0xc201:
-	case 0xc202:
-	case 0xc204:
-	case 0xc301:
-	case 0xc302:
-	case 0xc304:
-	case 0x00c5:
-	case 0x00d7:
-		bar_offset = 0x400;
-		break;
-	case 0x1680:
-	case 0x2052:
-	case 0x1681:
-		bar_offset = 0x0;
-		break;
-	default:
-		break;
-	}
+    switch (pdev->device) {
+    case 0xc201:
+    case 0xc202:
+    case 0xc204:
+    case 0xc301:
+    case 0xc302:
+    case 0xc304:
+    case 0x00c5:
+    case 0x00d7:
+        bar_offset = 0x400;
+        break;
+    case 0x1680:
+    case 0x2052:
+    case 0x1681:
+        bar_offset = 0x0;
+        break;
+    default:
+        break;
+    }
 
-	return bar_offset;
+    return bar_offset;
 }
 
 static int adv_pci_bar_len(const struct pci_dev *pdev)
 {
-	int len = 0x100;
+    int len = 0x100;
 
-	switch (pdev->device) {
+    switch (pdev->device) {
     case 0xc001:
     case 0xc002:
     case 0xc004:
@@ -211,180 +211,180 @@ static int adv_pci_bar_len(const struct pci_dev *pdev)
         len = 0x100;
         break;
 
-	case 0xc201:
-	case 0xc202:
-	case 0xc204:
-	case 0xc301:
-	case 0xc302:
-	case 0xc304:
-	case 0x00c5:
-	case 0x00d7:
-		len = 0x400;
-		break;
+    case 0xc201:
+    case 0xc202:
+    case 0xc204:
+    case 0xc301:
+    case 0xc302:
+    case 0xc304:
+    case 0x00c5:
+    case 0x00d7:
+        len = 0x400;
+        break;
 
-	case 0x1680:
-	case 0x1681:
-	case 0x2052:
+    case 0x1680:
+    case 0x1681:
+    case 0x2052:
     case 0x3680:
-		len = 0x80;
-		break;
+        len = 0x80;
+        break;
 
-	default:
-		break;
-	}
+    default:
+        break;
+    }
 
-	return len;
+    return len;
 }
 
 static int adv_pci_is_multi_bar(struct pci_dev *pdev)
 {
-	int is_multi_bar = 0;
+    int is_multi_bar = 0;
 
-	switch (pdev->device) {
-	case 0x1680:
-	case 0x2052:
-	case 0x1681:
-		is_multi_bar = 1;
-		break;
-	default:
-		break;
-	}
+    switch (pdev->device) {
+    case 0x1680:
+    case 0x2052:
+    case 0x1681:
+        is_multi_bar = 1;
+        break;
+    default:
+        break;
+    }
 
-	return is_multi_bar;
+    return is_multi_bar;
 }
 
 static int adv_pci_reg_shift(struct pci_dev *pdev)
 {
-	int reg_shift = 0;
+    int reg_shift = 0;
 
-	switch (pdev->device) {
-	case 0xc201:
-	case 0xc202:
-	case 0xc204:
-	case 0xc301:
-	case 0xc302:
-	case 0xc304:
-	case 0x00c5:
-	case 0x00d7:
-		// These devices support memory mapped IO.
-		// (not implemented by the driver)
-		reg_shift = 2;
-		break;
-	default:
-		break;
-	}
+    switch (pdev->device) {
+    case 0xc201:
+    case 0xc202:
+    case 0xc204:
+    case 0xc301:
+    case 0xc302:
+    case 0xc304:
+    case 0x00c5:
+    case 0x00d7:
+        // These devices support memory mapped IO.
+        // (not implemented by the driver)
+        reg_shift = 2;
+        break;
+    default:
+        break;
+    }
 
-	return reg_shift;
+    return reg_shift;
 }
 
 static int adv_pci_reset(const struct sja1000_priv *priv)
 {
-	unsigned char res;
+    unsigned char res;
 
-	/* Make sure SJA1000 is in reset mode */
-	priv->write_reg(priv, SJA1000_MOD, 1);
+    /* Make sure SJA1000 is in reset mode */
+    priv->write_reg(priv, SJA1000_MOD, 1);
 
-	/* Set PeliCAN mode */
-	priv->write_reg(priv, SJA1000_CDR, CDR_PELICAN);
+    /* Set PeliCAN mode */
+    priv->write_reg(priv, SJA1000_CDR, CDR_PELICAN);
 
-	/* check if mode is set */
-	res = priv->read_reg(priv, SJA1000_CDR);
+    /* check if mode is set */
+    res = priv->read_reg(priv, SJA1000_CDR);
 
-	if (res != CDR_PELICAN)
-		return -EIO;
+    if (res != CDR_PELICAN)
+        return -EIO;
 
-	return 0;
+    return 0;
 }
 
 static void adv_pci_del_all_channels(struct pci_dev *pdev)
 {
-	struct net_device *dev;
-	struct sja1000_priv *priv;
-	struct adv_pci *board;
-	int i;
+    struct net_device *dev;
+    struct sja1000_priv *priv;
+    struct adv_pci *board;
+    int i;
 
-	board = pci_get_drvdata(pdev);
-	if (!board)
-		return;
+    board = pci_get_drvdata(pdev);
+    if (!board)
+        return;
 
-	for (i = 0; i < board->no_channels; i++) {
-		if (!board->slave_dev[i])
-			continue;
+    for (i = 0; i < board->no_channels; i++) {
+        if (!board->slave_dev[i])
+            continue;
 
-		dev = board->slave_dev[i];
-		if (!dev)
-			continue;
+        dev = board->slave_dev[i];
+        if (!dev)
+            continue;
 
-		dev_info(&board->pci_dev->dev, "Removing device %s\n",
-			dev->name);
+        dev_info(&board->pci_dev->dev, "Removing device %s\n",
+            dev->name);
 
-		priv = netdev_priv(dev);
+        priv = netdev_priv(dev);
 
-		unregister_sja1000dev(dev);
+        unregister_sja1000dev(dev);
 
-		pci_iounmap(board->pci_dev, priv->reg_base);
+        pci_iounmap(board->pci_dev, priv->reg_base);
 
-		free_sja1000dev(dev);
-		board->slave_dev[i] = NULL;
-	}
+        free_sja1000dev(dev);
+        board->slave_dev[i] = NULL;
+    }
 }
 
 static int adv_pci_add_chan(struct pci_dev *pdev, int channel, int bar_no)
 {
-	struct net_device *dev;
-	struct sja1000_priv *priv;
-	struct adv_pci *board;
-	struct adv_board_data *board_data;
-	int err;
-	int bar_offset, bar_len, reg_shift;
+    struct net_device *dev;
+    struct sja1000_priv *priv;
+    struct adv_pci *board;
+    struct adv_board_data *board_data;
+    int err;
+    int bar_offset, bar_len, reg_shift;
     uintptr_t base_addr;
 
-	/* The following function calls assume device is supported */
-	bar_offset = adv_pci_bar_offset(pdev);
+    /* The following function calls assume device is supported */
+    bar_offset = adv_pci_bar_offset(pdev);
     bar_len = adv_pci_bar_len(pdev);
-	reg_shift = adv_pci_reg_shift(pdev);
+    reg_shift = adv_pci_reg_shift(pdev);
 
-	dev = alloc_sja1000dev(sizeof(struct adv_board_data));
-	if (dev == NULL)
-		return -ENOMEM;
+    dev = alloc_sja1000dev(sizeof(struct adv_board_data));
+    if (dev == NULL)
+        return -ENOMEM;
 
-	priv = netdev_priv(dev);
-	board_data = priv->priv;
+    priv = netdev_priv(dev);
+    board_data = priv->priv;
 
-	board_data->reg_shift = reg_shift;
+    board_data->reg_shift = reg_shift;
 
     base_addr = pci_resource_start(pdev, bar_no) + bar_offset * channel;
     priv->reg_base = ioremap(base_addr, bar_len);
 
-	priv->read_reg = adv_pci_read_reg;
-	priv->write_reg = adv_pci_write_reg;
+    priv->read_reg = adv_pci_read_reg;
+    priv->write_reg = adv_pci_write_reg;
 
-	priv->can.clock.freq = ADV_PCI_CAN_CLOCK;
+    priv->can.clock.freq = ADV_PCI_CAN_CLOCK;
 
-	priv->ocr = ADV_PCI_OCR;
-	priv->cdr = ADV_PCI_CDR;
+    priv->ocr = ADV_PCI_OCR;
+    priv->cdr = ADV_PCI_CDR;
 
-	priv->irq_flags = IRQF_SHARED;
-	dev->irq = pdev->irq;
+    priv->irq_flags = IRQF_SHARED;
+    dev->irq = pdev->irq;
 
-	board = pci_get_drvdata(pdev);
-	board->pci_dev = pdev;
-	board->slave_dev[channel] = dev;
+    board = pci_get_drvdata(pdev);
+    board->pci_dev = pdev;
+    board->slave_dev[channel] = dev;
 
-	dev_info(&pdev->dev, "reg_base=%p irq=%d\n",
+    dev_info(&pdev->dev, "reg_base=%p irq=%d\n",
             priv->reg_base, dev->irq);
 
-	if (adv_pci_reset(priv) == 0) {
-	    SET_NETDEV_DEV(dev, &pdev->dev);
-	    dev->dev_id = channel;
+    if (adv_pci_reset(priv) == 0) {
+        SET_NETDEV_DEV(dev, &pdev->dev);
+        dev->dev_id = channel;
 
-	    /* Register SJA1000 device */
-	    err = register_sja1000dev(dev);
-	    if (err) {
-		    dev_err(&pdev->dev, "Registering device failed (err=%d)\n",
-			    err);
-		    goto failure;
-	    }
+        /* Register SJA1000 device */
+        err = register_sja1000dev(dev);
+        if (err) {
+            dev_err(&pdev->dev, "Registering device failed (err=%d)\n",
+                err);
+            goto failure;
+        }
     }
     else {
         log_err("adv_pci_reset failed\n");
@@ -392,91 +392,91 @@ static int adv_pci_add_chan(struct pci_dev *pdev, int channel, int bar_no)
         free_sja1000dev(dev);
     }
 
-	return 0;
+    return 0;
 
 failure:
-	adv_pci_del_all_channels(pdev);
-	return err;
+    adv_pci_del_all_channels(pdev);
+    return err;
 }
 
 static void adv_pci_remove_one(struct pci_dev *pdev)
 {
-	struct adv_pci *board = pci_get_drvdata(pdev);
+    struct adv_pci *board = pci_get_drvdata(pdev);
 
-	dev_info(&pdev->dev, "Removing card\n");
+    dev_info(&pdev->dev, "Removing card\n");
 
-	adv_pci_del_all_channels(pdev);
+    adv_pci_del_all_channels(pdev);
 
-	kfree(board);
+    kfree(board);
 
-	pci_disable_device(pdev);
-	pci_set_drvdata(pdev, NULL);
+    pci_disable_device(pdev);
+    pci_set_drvdata(pdev, NULL);
 }
 
 static int adv_pci_init_one(struct pci_dev *pdev,
-				const struct pci_device_id *ent)
+                const struct pci_device_id *ent)
 {
-	struct adv_pci *board;
+    struct adv_pci *board;
 
-	int i, err;
-	int no_channels, bar_no, is_multi_bar;
+    int i, err;
+    int no_channels, bar_no, is_multi_bar;
 
-	err = 0;
+    err = 0;
 
-	dev_info(&pdev->dev, "initializing device %04x:%04x\n",
-		pdev->vendor, pdev->device);
+    dev_info(&pdev->dev, "initializing device %04x:%04x\n",
+        pdev->vendor, pdev->device);
 
-	board = kzalloc(sizeof(struct adv_pci), GFP_KERNEL);
-	if (board == NULL)
-		goto failure;
+    board = kzalloc(sizeof(struct adv_pci), GFP_KERNEL);
+    if (board == NULL)
+        goto failure;
 
-	err = pci_enable_device(pdev);
-	if (err)
-		goto failure;
+    err = pci_enable_device(pdev);
+    if (err)
+        goto failure;
 
-	err = adv_pci_device_support_check(pdev);
-	if (err)
-		goto failure_release_pci;
+    err = adv_pci_device_support_check(pdev);
+    if (err)
+        goto failure_release_pci;
 
-	no_channels = number_of_sja1000_chips(pdev);
-	if (no_channels == 0) {
-		err = -ENOMEM;
-		goto failure_release_pci;
-	}
+    no_channels = number_of_sja1000_chips(pdev);
+    if (no_channels == 0) {
+        err = -ENOMEM;
+        goto failure_release_pci;
+    }
 
-	/* The following function calls assume device is supported */
-	bar_no = adv_pci_bar_no(pdev);
-	is_multi_bar = adv_pci_is_multi_bar(pdev);
+    /* The following function calls assume device is supported */
+    bar_no = adv_pci_bar_no(pdev);
+    is_multi_bar = adv_pci_is_multi_bar(pdev);
 
-	board->no_channels = no_channels;
+    board->no_channels = no_channels;
 
-	pci_set_drvdata(pdev, board);
+    pci_set_drvdata(pdev, board);
 
-	for (i = 0; i < no_channels; i++) {
-		err = adv_pci_add_chan(pdev, i, bar_no);
-		if (err)
-			goto failure_cleanup;
+    for (i = 0; i < no_channels; i++) {
+        err = adv_pci_add_chan(pdev, i, bar_no);
+        if (err)
+            goto failure_cleanup;
 
-		if (is_multi_bar)
-			bar_no++;
-	}
-	return 0;
+        if (is_multi_bar)
+            bar_no++;
+    }
+    return 0;
 
 failure_cleanup:
-	adv_pci_remove_one(pdev);
+    adv_pci_remove_one(pdev);
 
 failure_release_pci:
-	pci_disable_device(pdev);
+    pci_disable_device(pdev);
 
 failure:
-	return err;
+    return err;
 }
 
 /*static */struct pci_driver adv_pci_driver = {
-	.name = DRV_NAME,
-	.id_table = adv_pci_tbl,
-	.probe = adv_pci_init_one,
-	.remove = adv_pci_remove_one
+    .name = DRV_NAME,
+    .id_table = adv_pci_tbl,
+    .probe = adv_pci_init_one,
+    .remove = adv_pci_remove_one
 };
 
 module_pci_driver(adv_pci_driver);

--- a/src/kernel/include/linux/io.h
+++ b/src/kernel/include/linux/io.h
@@ -35,11 +35,13 @@
 #include <sys/mman.h>
 #include <hw/inout.h> /* QNX header */
 
+extern size_t io_port_addr_threshold;
+
 
 static inline uint8_t read8 (void __iomem* addr) {
     uint8_t ret;
 
-    if ((uintptr_t)addr <= 0xFFFF) {
+    if ((uintptr_t)addr < io_port_addr_threshold) {
         ret = in8((uintptr_t __iomem)addr);
     }
     else {
@@ -54,7 +56,7 @@ static inline uint8_t read8 (void __iomem* addr) {
 static inline uint16_t read16 (void __iomem* addr) {
     uint16_t ret;
 
-    if ((uintptr_t)addr <= 0xFFFF) {
+    if ((uintptr_t)(addr + 1) < io_port_addr_threshold) {
         ret = in16((uintptr_t __iomem)addr);
     }
     else {
@@ -69,7 +71,7 @@ static inline uint16_t read16 (void __iomem* addr) {
 static inline uint32_t read32 (void __iomem* addr) {
     uint32_t ret;
 
-    if ((uintptr_t)addr <= 0xFFFF) {
+    if ((uintptr_t)(addr + 3) < io_port_addr_threshold) {
         ret = in32((uintptr_t __iomem)addr);
     }
     else {
@@ -82,7 +84,7 @@ static inline uint32_t read32 (void __iomem* addr) {
 }
 
 static inline void write8 (void __iomem* addr, uint8_t val) {
-    if ((uintptr_t)addr <= 0xFFFF) {
+    if ((uintptr_t)addr < io_port_addr_threshold) {
         out8((__iomem uintptr_t)addr, val);
     }
     else {
@@ -92,7 +94,7 @@ static inline void write8 (void __iomem* addr, uint8_t val) {
 }
 
 static inline void write16 (void __iomem* addr, uint16_t val) {
-    if ((uintptr_t)addr <= 0xFFFF) {
+    if ((uintptr_t)(addr + 1) < io_port_addr_threshold) {
         out16((__iomem uintptr_t)addr, val);
     }
     else {
@@ -102,7 +104,7 @@ static inline void write16 (void __iomem* addr, uint16_t val) {
 }
 
 static inline void write32 (void __iomem* addr, uint32_t val) {
-    if ((uintptr_t)addr <= 0xFFFF) {
+    if ((uintptr_t)(addr + 3) < io_port_addr_threshold) {
         out32((__iomem uintptr_t)addr, val);
     }
     else {


### PR DESCRIPTION
…or non-x86 architectures.

- Read and write functions in src/kernel/include/linux/io.h utilize a static memory region check (of address 0-0xFFFF) to determine when to use I/O port functions in*() and out*(). For addresses beyond this region, functions utilize memory address operations with the appropriate memory barriers.
- This however much not elegant, works fine for x86 platform, however for non-x86 platform it could be problematic. For example, if on some architectures the PCI device bar memory regions with address 0-0xFFFF come up as MEM (or memory mapped regions) instead of I/O port regions, then the read and write functions will still use the static 0xFFFF region threshold check to direct the operations to in*() and out*() functions. These functions correspond to x86 in* and out* assembler operations, which perhaps won't work on other architectures, depends on how QNX has implemented the in*() and out*() functions.
- Nevertheless, a better implementation would be to track the PCI bar I/O and MEM address blocks and use a more specific I/O memory threshold in read and write functions. This will still give us a simple and fast check, more over still a correct check. When run on x86 platform, this more specific threshold can be more precise and on non-x86 platform the threshold would be 0 and thus all operations will be done as memory operations.
- A further benefit of such an implementation would be the behaviour of the read and write functions will be determined by the src/pci.c functions that are responsible for managing the PCI interface for QNX implementation.