### PR TITLE
Support QNX standard/extended MID configurations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ list( APPEND C_SOURCE_FILES
     ${CMAKE_SOURCE_DIR}/src/netif.c
     ${CMAKE_SOURCE_DIR}/src/pci.c
     ${CMAKE_SOURCE_DIR}/src/prints.c
+    ${CMAKE_SOURCE_DIR}/src/driver-prints.c
     ${CMAKE_SOURCE_DIR}/src/queue.c
     ${CMAKE_SOURCE_DIR}/src/resmgr.c
     ${CMAKE_SOURCE_DIR}/src/session.c

--- a/README.md
+++ b/README.md
@@ -409,6 +409,15 @@ All RX file descriptor clients have the possibility of receiving the TX echo
 back messages (unless they have their filters configured to mask them).
 
 
+## Note about MIDs
+
+Message IDs or MIDs are slightly different on QNX compared to Linux. The form of
+the ID depends on whether or not the driver is using extended MIDs:
+
+- In standard 11-bit MIDs, bits 18–28 define the MID.
+- In extended 29-bit MIDs, bits 0–28 define the MID.
+
+
 ## Check Supported Hardware
 
 Run with '-i' option to check what hardware is supported:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Options:
                           e.g. /dev/can0/ is id=0
                  rx=#   - Number of RX file descriptors to create
                  tx=#   - Number of TX file descriptors to create
+                 s      - Start the device with standard MIDs
+                 x      - Start the device with extended MIDs
+                          Default: is setup as standard MIDs or determined by
+                          driver level -x option if specified
 
                  Example:
                      dev-can-linux -u id=0,rx=2,tx=0
@@ -63,6 +67,8 @@ Options:
     -b delay   - Bus-off recovery delay timer length (milliseconds).
                  If set to 0ms, then the bus-off recovery is disabled!
                  Default: 50ms
+    -x         - Start the driver with extended MIDs enabled.
+                 Device suboptions take precedence over this option.
     -?/h       - Print help menu and exit.
 
     NOTES
@@ -160,7 +166,7 @@ Here are some other examples where specific fields are selected:
 To get further verification you can query the canctl tool for channel
 information:
 
-    canctl -u0,rx0 -i       
+    canctl -u0,rx0 -i
 
 Sample output:
 
@@ -188,7 +194,7 @@ to a channel:
 
 Then to send to the same channel, use cansend tool:
 
-    cansend -u0,tx0 -w0x1234,1,0xABCD
+    cansend -u0,tx0 -m0x1234,1,0xABCD
 
 Sample output:
 
@@ -196,7 +202,7 @@ Sample output:
 
 To get statistics on sends, receives, errors and more:
 
-    canctl -u0,rx0 -s                       
+    canctl -u0,rx0 -s
 
 Sample output:
 
@@ -316,9 +322,12 @@ that facilitate application interfaces to the driver.
 Diagram below illustrates device folders and RX/TX file descriptors and how to
 configure them.
 
-    dev-can-linux -u id=0,rx=n,tx=m     # Example driver start command
+    dev-can-linux -u id=0,rx=n,tx=m,x   # Example driver start command
     │                                   # Asking for n rx and m tx channels
     │                                   # for port 0.
+    |                                   # `x` specifies extended MIDs to be used
+    |                                   # read/write, this is ignored for devctl
+    |                                   # functionality.
     │                                   # Note n and m can be zero also.
     │
     ├── /dev/can0/  # When you start the driver these device directories
@@ -374,6 +383,9 @@ configure them.
         │           Example driver start command didn't specify anything for
         │           this device, so the default behaviour of creating a single
         │           RX and TX file decriptor will be performed.
+        |           This channel will have the default standard MIDs for read
+        |           and write functionality; not applicable for devctl or direct
+        |           send/receive operations.
         │
         ├── rx0
         │   ├── client connection to read  1

--- a/dev-can-linux/commands.h
+++ b/dev-can-linux/commands.h
@@ -54,6 +54,24 @@
 #define EXT_CAN_CMD_CODE                    0x54
 #define EXT_CAN_DEVCTL_SET_LATENCY_LIMIT_MS __DIOT(_DCMD_MISC, EXT_CAN_CMD_CODE + 0,  uint32_t)
 
+/**
+ * Special Note
+ *
+ * When using functions:
+ *      write_frame_raw()
+ *      read_frame_raw_block()
+ *      read_frame_raw_noblock()
+ *      set_mid()
+ *      get_mid()
+ *      set_mfilter()
+ *      get_mfilter()
+ *
+ * Message IDs or MIDs are slightly different on QNX compared to Linux. The form
+ * of the ID depends on whether or not the driver is using extended MIDs:
+ *
+ *      - In standard 11-bit MIDs, bits 18–28 define the MID.
+ *      - In extended 29-bit MIDs, bits 0–28 define the MID.
+ */
 
 static inline int write_frame_raw (int filedes, struct can_msg* canmsg) {
     if (canmsg == NULL) {

--- a/src/config.c
+++ b/src/config.c
@@ -45,6 +45,8 @@
 
 /*
  * Program options, initial values
+ *
+ * See print_help() or dev-can-linux -h for details
  */
 int optb = 0;
 int optb_restart_ms = DEFAULT_RESTART_MS;
@@ -56,6 +58,7 @@ int optd = 0, opt_vid = -1, opt_did = -1;
 int opts = 0;
 int optt = 0;
 int optu = 0;
+int optx = 0;
 
 size_t num_optu_configs = 0;
 channel_config_t* optu_config = NULL;

--- a/src/driver-prints.c
+++ b/src/driver-prints.c
@@ -1,0 +1,95 @@
+/*
+ * \file    driver-prints.c
+ *
+ * Copyright (C) 2022 Deniz Eren <deniz.eren@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdio.h>
+
+#include "driver-prints.h"
+#include "config.h"
+#include "pci.h"
+
+
+void print_driver_selection_results() {
+    driver_selection_t** location = &driver_selection_root;
+
+    while (*location != NULL) {
+        log_info("Auto detected device (%x:%x) successfully: (driver \"%s\")\n",
+                (*location)->pdev.vendor,
+                (*location)->pdev.device,
+                (*location)->driver->name);
+
+        location = &(*location)->next;
+    }
+}
+
+static void print_card (FILE* file, const struct pci_driver* driver) {
+    fprintf(file, "  Driver: \e[1m%s\e[m\n", driver->name);
+    fprintf(file, "  Supported devices (detailed):\n");
+
+    if (driver->id_table != NULL) {
+        const struct pci_device_id *id_table = driver->id_table;
+
+        while (id_table->vendor != 0) {
+            fprintf(file, "    { vendor: \e[1m%x\e[m, device: \e[1m%x\e[m, subvendor: %x, "
+                                "subdevice: %x, class: %x, class_mask: %x }\n",
+                id_table->vendor,
+                id_table->device,
+                id_table->subvendor,
+                id_table->subdevice,
+                id_table->class,
+                id_table->class_mask);
+            ++id_table;
+        }
+    }
+}
+
+void print_support (int detailed) {
+    print_notice();
+
+    printf("\n");
+
+    if (detailed) {
+        printf("\e[1mAdvantech PCI cards:\e[m\n");
+        print_card(stdout, &adv_pci_driver);
+
+        printf("\e[1mKVASER PCAN PCI cards:\e[m\n");
+        print_card(stdout, &kvaser_pci_driver);
+
+        printf("\e[1mEMS CPC-PCI/PCIe/104P CAN cards:\e[m\n");
+        print_card(stdout, &ems_pci_driver);
+
+        printf("\e[1mPEAK PCAN PCI family cards:\e[m\n");
+        print_card(stdout, &peak_pci_driver);
+
+        printf("\e[1mPLX90xx PCI-bridge cards (with the SJA1000 chips):\e[m\n");
+        print_card(stdout, &plx_pci_driver);
+
+        return;
+    }
+
+    printf("Supports:\n");
+    printf("  - Advantech PCI cards\n");
+    printf("  - KVASER PCAN PCI cards\n");
+    printf("  - EMS CPC-PCI/PCIe/104P CAN cards\n");
+    printf("  - PEAK PCAN PCI family cards\n");
+    printf("  - PLX90xx PCI-bridge cards (with the SJA1000 chips)\n");
+    printf("\n");
+    printf("For more details use option `\e[1m-ii\e[m'\n");
+}
+

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -37,6 +37,8 @@
 
 /*
  * Program options
+ *
+ * See print_help() or dev-can-linux -h for details
  */
 
 extern int optb;
@@ -51,11 +53,13 @@ extern int opt_did;
 extern int opts;
 extern int optt;
 extern int optu;
+extern int optx;
 
 typedef struct channel_config {
     int id;
     int num_rx_channels;
     int num_tx_channels;
+    int is_extended_mid;
 } channel_config_t;
 
 extern size_t num_optu_configs;

--- a/src/include/driver-prints.h
+++ b/src/include/driver-prints.h
@@ -1,5 +1,5 @@
 /*
- * \file    prints.h
+ * \file    driver-prints.h
  *
  * Copyright (C) 2022 Deniz Eren <deniz.eren@outlook.com>
  *
@@ -18,16 +18,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef SRC_PRINTS_H_
-#define SRC_PRINTS_H_
+#ifndef SRC_DRIVER_PRINTS_H_
+#define SRC_DRIVER_PRINTS_H_
 
+#include "prints.h"
 
 /* Info prints */
-extern void print_version (void);
-extern void print_configs (void);
-extern void print_notice (void);
-extern void print_help (char* program_name);
-extern void print_warranty (void);
-extern void print_license (void);
+extern void print_support (int detailed);
 
-#endif /* SRC_PRINTS_H_ */
+#endif /* SRC_DRIVER_PRINTS_H_ */

--- a/src/include/resmgr.h
+++ b/src/include/resmgr.h
@@ -132,6 +132,8 @@ typedef struct can_resmgr {
 
     device_session_t* device_session;
     struct driver_selection* driver_selection;
+    int is_extended_mid; // Only applicable for read and write functions not
+                         // used for direct devctl send/receive functionality.
 
     char name[MAX_NAME_SIZE];
     channel_type_t channel_type;

--- a/src/prints.c
+++ b/src/prints.c
@@ -1,4 +1,6 @@
 /*
+ * \file    prints.c
+ *
  * Copyright (C) 2022 Deniz Eren <deniz.eren@outlook.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,7 +21,6 @@
 #include <stdio.h>
 
 #include "config.h"
-#include "pci.h"
 
 
 void print_version (void) {
@@ -61,74 +62,6 @@ void print_notice (void) {
             "option `\e[1m-w\e[m'.\n");
     printf("This is free software, and you are welcome to redistribute it\n");
     printf("under certain conditions; option `\e[1m-c\e[m' for details.\n");
-}
-
-void print_driver_selection_results() {
-    driver_selection_t** location = &driver_selection_root;
-
-    while (*location != NULL) {
-        log_info("Auto detected device (%x:%x) successfully: (driver \"%s\")\n",
-                (*location)->pdev.vendor,
-                (*location)->pdev.device,
-                (*location)->driver->name);
-
-        location = &(*location)->next;
-    }
-}
-
-static void print_card (FILE* file, const struct pci_driver* driver) {
-    fprintf(file, "  Driver: \e[1m%s\e[m\n", driver->name);
-    fprintf(file, "  Supported devices (detailed):\n");
-
-    if (driver->id_table != NULL) {
-        const struct pci_device_id *id_table = driver->id_table;
-
-        while (id_table->vendor != 0) {
-            fprintf(file, "    { vendor: \e[1m%x\e[m, device: \e[1m%x\e[m, subvendor: %x, "
-                                "subdevice: %x, class: %x, class_mask: %x }\n",
-                id_table->vendor,
-                id_table->device,
-                id_table->subvendor,
-                id_table->subdevice,
-                id_table->class,
-                id_table->class_mask);
-            ++id_table;
-        }
-    }
-}
-
-void print_support (bool detailed) {
-    print_notice();
-
-    printf("\n");
-
-    if (detailed) {
-        printf("\e[1mAdvantech PCI cards:\e[m\n");
-        print_card(stdout, &adv_pci_driver);
-
-        printf("\e[1mKVASER PCAN PCI cards:\e[m\n");
-        print_card(stdout, &kvaser_pci_driver);
-
-        printf("\e[1mEMS CPC-PCI/PCIe/104P CAN cards:\e[m\n");
-        print_card(stdout, &ems_pci_driver);
-
-        printf("\e[1mPEAK PCAN PCI family cards:\e[m\n");
-        print_card(stdout, &peak_pci_driver);
-
-        printf("\e[1mPLX90xx PCI-bridge cards (with the SJA1000 chips):\e[m\n");
-        print_card(stdout, &plx_pci_driver);
-
-        return;
-    }
-
-    printf("Supports:\n");
-    printf("  - Advantech PCI cards\n");
-    printf("  - KVASER PCAN PCI cards\n");
-    printf("  - EMS CPC-PCI/PCIe/104P CAN cards\n");
-    printf("  - PEAK PCAN PCI family cards\n");
-    printf("  - PLX90xx PCI-bridge cards (with the SJA1000 chips)\n");
-    printf("\n");
-    printf("For more details use option `\e[1m-ii\e[m'\n");
 }
 
 void print_help (char* program_name) {

--- a/tools/candump/CMakeLists.txt
+++ b/tools/candump/CMakeLists.txt
@@ -20,10 +20,17 @@
 #
 
 add_executable( candump
+    ${CMAKE_SOURCE_DIR}/src/prints.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/candump.c )
 
 target_include_directories( candump PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/include/uapi>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/arch/x86/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/> )
 
 if( CMAKE_BUILD_TYPE MATCHES Profiling )

--- a/tools/candump/README.md
+++ b/tools/candump/README.md
@@ -1,0 +1,27 @@
+# CANDUMP (DEV-CAN-LINUX)
+
+CANDUMP is an accompanying tool used to read raw CAN messages.
+
+## Usage
+
+The compiled program is used as follows:
+
+    candump [options]
+
+Options:
+
+    -u subopts - Specify the device RX file descriptors.
+
+                 Suboptions (subopts):
+
+                 #      - Specify ID number of the device to configure;
+                          e.g. /dev/can0/ is -u0
+                 rx#    - ID of RX file descriptors to connect to
+
+                 Example:
+                     candump -u0,rx0
+
+    -w         - Print warranty message and exit.
+    -c         - Print license details and exit.
+    -?/h       - Print help menu and exit.
+

--- a/tools/candump/src/candump.c
+++ b/tools/candump/src/candump.c
@@ -137,7 +137,15 @@ int main (int argc, char* argv[]) {
                     OPEN_FILE,
                     canmsg.ext.timestamp,
                     canmsg.ext.is_extended_mid ? "EFF" : "SFF",
-                    canmsg.mid,
+                    /**
+                     * Message IDs or MIDs are slightly different on QNX compared
+                     * to Linux. The form of the ID depends on whether or not the
+                     * driver is using extended MIDs:
+                     *
+                     *      - In standard 11-bit MIDs, bits 18–28 define the MID.
+                     *      - In extended 29-bit MIDs, bits 0–28 define the MID.
+                     */
+                    canmsg.ext.is_extended_mid ? canmsg.mid : canmsg.mid >> 18,
                     canmsg.len,
                     canmsg.dat[0],
                     canmsg.dat[1],

--- a/tools/candump/src/candump.c
+++ b/tools/candump/src/candump.c
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <prints.h>
 #include <dev-can-linux/commands.h>
 
 
@@ -31,6 +32,39 @@ static void sigint_signal_handler (int sig_no) {
     exit(0);
 }
 
+void help (char* program_name) {
+    print_notice();
+
+    printf("\n");
+    printf("\e[1mSYNOPSIS\e[m\n");
+    printf("    \e[1m%s\e[m [options]\n", program_name);
+    printf("\n");
+    printf("\e[1mDESCRIPTION\e[m\n");
+    printf("    \e[1mDEV-CAN-LINUX\e[m is a QNX CAN-bus driver project that aims at porting drivers\n");
+    printf("    from the open-source Linux Kernel project to QNX RTOS.\n");
+    printf("\n");
+    printf("    \e[1mCANDUMP\e[m is an accompanying tool used to read raw CAN messages.\n");
+    printf("\n");
+    printf("\e[1mOPTIONS\e[m\n");
+    printf("    \e[1m-u subopts\e[m - Specify the device RX file descriptors.\n");
+    printf("\n");
+    printf("                 Suboptions (\e[1msubopts\e[m):\n");
+    printf("\n");
+    printf("                 \e[1m#\e[m      - Specify ID number of the device to configure;\n");
+    printf("                          e.g. /dev/can0/ is -u0\n");
+    printf("                 \e[1mrx#\e[m    - ID of RX file descriptors to connect to\n");
+    printf("\n");
+    printf("                 Example:\n");
+    printf("                     candump -u0,rx0\n");
+    printf("\n");
+    printf("    \e[1m-w\e[m         - Print warranty message and exit.\n");
+    printf("    \e[1m-c\e[m         - Print license details and exit.\n");
+    printf("    \e[1m-?/h\e[m       - Print help menu and exit.\n");
+    printf("\n");
+    printf("\e[1mBUGS\e[m\n");
+    printf("    If you find a bug, please report it.\n");
+}
+
 int main (int argc, char* argv[]) {
     int opt;
     char* buffer;
@@ -40,7 +74,7 @@ int main (int argc, char* argv[]) {
     int optu_mailbox_is_tx = 0;
     int optu_mailbox = 0;
 
-    while ((opt = getopt(argc, argv, "u:?h")) != -1) {
+    while ((opt = getopt(argc, argv, "u:wc?h")) != -1) {
         switch (opt) {
         case 'u':
             buffer = optu_mailbox_str;
@@ -60,8 +94,17 @@ int main (int argc, char* argv[]) {
             sscanf(optu_mailbox_str+2, "%d", &optu_mailbox);
             break;
 
+        case 'w':
+            print_warranty();
+            return EXIT_SUCCESS;
+
+        case 'c':
+            print_license();
+            return EXIT_SUCCESS;
+
         case '?':
         case 'h':
+            help(argv[0]);
             return EXIT_SUCCESS;
 
         default:

--- a/tools/canread/CMakeLists.txt
+++ b/tools/canread/CMakeLists.txt
@@ -20,10 +20,17 @@
 #
 
 add_executable( canread
+    ${CMAKE_SOURCE_DIR}/src/prints.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/canread.c )
 
 target_include_directories( canread PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/include/uapi>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/arch/x86/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/> )
 
 if( CMAKE_BUILD_TYPE MATCHES Profiling )

--- a/tools/canread/README.md
+++ b/tools/canread/README.md
@@ -1,0 +1,27 @@
+# CANREAD (DEV-CAN-LINUX)
+
+CANREAD is an accompanying tool used to read textual bytes from CAN messages.
+
+## Usage
+
+The compiled program is used as follows:
+
+    canread [options]
+
+Options:
+
+    -u subopts - Specify the device RX file descriptors.
+
+                 Suboptions (subopts):
+
+                 #      - Specify ID number of the device to configure;
+                          e.g. /dev/can0/ is -u0
+                 rx#    - ID of RX file descriptors to connect to
+
+                 Example:
+                     canread -u0,rx0
+
+    -n bytes   - Number of bytes to receive before flushing to stdout.
+    -w         - Print warranty message and exit.
+    -c         - Print license details and exit.
+    -?/h       - Print help menu and exit.

--- a/tools/canread/src/canread.c
+++ b/tools/canread/src/canread.c
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <prints.h>
 #include <dev-can-linux/commands.h>
 
 
@@ -31,6 +32,50 @@ static void sigint_signal_handler (int sig_no) {
     exit(0);
 }
 
+void help (char* program_name) {
+    print_notice();
+
+    printf("\n");
+    printf("\e[1mSYNOPSIS\e[m\n");
+    printf("    \e[1m%s\e[m [options]\n", program_name);
+    printf("\n");
+    printf("\e[1mDESCRIPTION\e[m\n");
+    printf("    \e[1mDEV-CAN-LINUX\e[m is a QNX CAN-bus driver project that aims at porting drivers\n");
+    printf("    from the open-source Linux Kernel project to QNX RTOS.\n");
+    printf("\n");
+    printf("    \e[1mCANREAD\e[m is an accompanying tool used to read textual bytes from CAN\n");
+    printf("    messages.\n");
+    printf("\n");
+    printf("\e[1mOPTIONS\e[m\n");
+    printf("    \e[1m-u subopts\e[m - Specify the device RX file descriptors.\n");
+    printf("\n");
+    printf("                 Suboptions (\e[1msubopts\e[m):\n");
+    printf("\n");
+    printf("                 \e[1m#\e[m      - Specify ID number of the device to configure;\n");
+    printf("                          e.g. /dev/can0/ is -u0\n");
+    printf("                 \e[1mrx#\e[m    - ID of RX file descriptors to connect to\n");
+    printf("\n");
+    printf("                 Example:\n");
+    printf("                     canread -u0,rx0\n");
+    printf("\n");
+    printf("    \e[1m-n bytes\e[m   - Number of bytes to receive before flushing to stdout.\n");
+    printf("    \e[1m-w\e[m         - Print warranty message and exit.\n");
+    printf("    \e[1m-c\e[m         - Print license details and exit.\n");
+    printf("    \e[1m-?/h\e[m       - Print help menu and exit.\n");
+    printf("\n");
+    printf("\e[1mEXAMPLES\e[m\n");
+    printf("    Receive bytes:\n");
+    printf("\n");
+    printf("        \e[1mcanread -u0,rx0\e[m\n");
+    printf("\n");
+    printf("    Send bytes to see from another terminal:\n");
+    printf("\n");
+    printf("        \e[1mecho -n abc > /dev/can0/tx0\e[m\n");
+    printf("\n");
+    printf("\e[1mBUGS\e[m\n");
+    printf("    If you find a bug, please report it.\n");
+}
+
 int main (int argc, char* argv[]) {
     int opt;
     char* buffer;
@@ -40,9 +85,9 @@ int main (int argc, char* argv[]) {
     int optu_mailbox_is_tx = 0;
     int optu_mailbox = 0;
 
-    int optW = 1;
+    int optn = 1;
 
-    while ((opt = getopt(argc, argv, "u:W:?h")) != -1) {
+    while ((opt = getopt(argc, argv, "u:n:wc?h")) != -1) {
         switch (opt) {
         case 'u':
             buffer = optu_mailbox_str;
@@ -62,12 +107,21 @@ int main (int argc, char* argv[]) {
             sscanf(optu_mailbox_str+2, "%d", &optu_mailbox);
             break;
 
-        case 'W':
-            optW = atoi(optarg);
+        case 'n':
+            optn = atoi(optarg);
             break;
+
+        case 'w':
+            print_warranty();
+            return EXIT_SUCCESS;
+
+        case 'c':
+            print_license();
+            return EXIT_SUCCESS;
 
         case '?':
         case 'h':
+            help(argv[0]);
             return EXIT_SUCCESS;
 
         default:
@@ -94,7 +148,7 @@ int main (int argc, char* argv[]) {
     }
 
     while (ret == EOK) {
-        ssize_t n = read(fd, (void*)buf, optW);
+        ssize_t n = read(fd, (void*)buf, optn);
 
         if (n == -1) {
             printf("canread error: %s\n", strerror(errno));

--- a/tools/cansend/CMakeLists.txt
+++ b/tools/cansend/CMakeLists.txt
@@ -20,10 +20,17 @@
 #
 
 add_executable( cansend
+    ${CMAKE_SOURCE_DIR}/src/prints.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cansend.c )
 
 target_include_directories( cansend PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/include/uapi>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/kernel/arch/x86/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/> )
 
 if( CMAKE_BUILD_TYPE MATCHES Profiling )

--- a/tools/cansend/README.md
+++ b/tools/cansend/README.md
@@ -1,0 +1,37 @@
+# CANSEND (DEV-CAN-LINUX)
+
+CANSEND is an accompanying tool used to send raw CAN messages.
+
+## Usage
+
+The compiled program is used as follows:
+
+    cansend [options]
+
+Options:
+
+    -u subopts - Specify the device TX file descriptors.
+
+                 Suboptions (subopts):
+
+                 #      - Specify ID number of the device to configure;
+                          e.g. /dev/can0/ is -u0
+                 tx#    - ID of TX file descriptors to connect to
+
+                 Example:
+                     cansend -u0,tx0 ...
+
+    -m subopts - Specify message details.
+
+                 Suboptions (subopts):
+
+                 #      - MID of message in hexadecimal
+                 #      - Standard (0) or Extended (1) MID
+                 #      - Message data in hexadecimal
+
+                 Example:
+                     cansend -m0x1234,1,0xABCD ...
+
+    -w         - Print warranty message and exit.
+    -c         - Print license details and exit.
+    -?/h       - Print help menu and exit.

--- a/tools/cansend/src/cansend.c
+++ b/tools/cansend/src/cansend.c
@@ -19,8 +19,62 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <prints.h>
 #include <dev-can-linux/commands.h>
 
+
+void help (char* program_name) {
+    print_notice();
+
+    printf("\n");
+    printf("\e[1mSYNOPSIS\e[m\n");
+    printf("    \e[1m%s\e[m [options]\n", program_name);
+    printf("\n");
+    printf("\e[1mDESCRIPTION\e[m\n");
+    printf("    \e[1mDEV-CAN-LINUX\e[m is a QNX CAN-bus driver project that aims at porting drivers\n");
+    printf("    from the open-source Linux Kernel project to QNX RTOS.\n");
+    printf("\n");
+    printf("    \e[1mCANSEND\e[m is an accompanying tool used to send raw CAN messages.\n");
+    printf("\n");
+    printf("\e[1mOPTIONS\e[m\n");
+    printf("    \e[1m-u subopts\e[m - Specify the device TX file descriptors.\n");
+    printf("\n");
+    printf("                 Suboptions (\e[1msubopts\e[m):\n");
+    printf("\n");
+    printf("                 \e[1m#\e[m      - Specify ID number of the device to configure;\n");
+    printf("                          e.g. /dev/can0/ is -u0\n");
+    printf("                 \e[1mtx#\e[m    - ID of TX file descriptors to connect to\n");
+    printf("\n");
+    printf("                 Example:\n");
+    printf("                     cansend -u0,tx0 ...\n");
+    printf("\n");
+    printf("    \e[1m-m subopts\e[m - Specify message details.\n");
+    printf("\n");
+    printf("                 Suboptions (\e[1msubopts\e[m):\n");
+    printf("\n");
+    printf("                 \e[1m#\e[m      - MID of message in hexadecimal\n");
+    printf("                 \e[1m#\e[m      - Standard (0) or Extended (1) MID\n");
+    printf("                 \e[1m#\e[m      - Message data in hexadecimal\n");
+    printf("\n");
+    printf("                 Example:\n");
+    printf("                     cansend -m0x1234,1,0xABCD ...\n");
+    printf("\n");
+    printf("    \e[1m-w\e[m         - Print warranty message and exit.\n");
+    printf("    \e[1m-c\e[m         - Print license details and exit.\n");
+    printf("    \e[1m-?/h\e[m       - Print help menu and exit.\n");
+    printf("\n");
+    printf("\e[1mEXAMPLES\e[m\n");
+    printf("    Send a standard MID message:\n");
+    printf("\n");
+    printf("        \e[1mcansend -u0,tx0 -m0x1234,0,0xABCD\e[m\n");
+    printf("\n");
+    printf("    Send a extended MID message:\n");
+    printf("\n");
+    printf("        \e[1mcansend -u0,tx0 -m0x1234,1,0xABCD\e[m\n");
+    printf("\n");
+    printf("\e[1mBUGS\e[m\n");
+    printf("    If you find a bug, please report it.\n");
+}
 
 int main (int argc, char* argv[]) {
     int opt;
@@ -35,7 +89,7 @@ int main (int argc, char* argv[]) {
     int optw_mid_type = 0;
     char optw_data_str[32];
 
-    while ((opt = getopt(argc, argv, "u:w:?h")) != -1) {
+    while ((opt = getopt(argc, argv, "u:m:wc?h")) != -1) {
         switch (opt) {
         case 'u':
             buffer = optu_mailbox_str;
@@ -55,14 +109,23 @@ int main (int argc, char* argv[]) {
             sscanf(optu_mailbox_str+2, "%d", &optu_mailbox);
             break;
 
-        case 'w':
+        case 'm':
             buffer = optw_data_str;
             sscanf(optarg, "0x%x,%d,0x%s", &optw_mid, &optw_mid_type, buffer);
 
             break;
 
+        case 'w':
+            print_warranty();
+            return EXIT_SUCCESS;
+
+        case 'c':
+            print_license();
+            return EXIT_SUCCESS;
+
         case '?':
         case 'h':
+            help(argv[0]);
             return EXIT_SUCCESS;
 
         default:


### PR DESCRIPTION
- Added read/write functionality MID configuration program options. These options do not impact on raw or direct devctl send/received options:
  * Added new driver option -x to specify extended MIDs; default is standard MIDs.
  * Added x (extended) and s (standard) MID configuration suboptions for device configuration program options.
- Restructured print.h/print.c to introduce driver-print.h/driver-print.c to allow the usage of these helper functions within the tool binaries also.
- Change option -w to -m for tool cansend.
- Added README.md files to the tool binaries.