### PR TITLE
Fixed transmission synchronisation dead-lock issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Options:
                  a particular device use this option.
     -b delay   - Bus-off recovery delay timer length (milliseconds).
                  If set to 0ms, then the bus-off recovery is disabled!
+                 The netif transmission queue fault recovery is also set to this
+                 delay value.
                  Default: 50ms
     -x         - Start the driver with extended MIDs enabled.
                  Device suboptions take precedence over this option.

--- a/src/session.c
+++ b/src/session.c
@@ -68,7 +68,11 @@ create_device_session (struct net_device* dev, const queue_attr_t* tx_attr) {
         return NULL;
     }
 
-    if ((result = pthread_cond_init(&new_device->cond, NULL)) != EOK) {
+    pthread_condattr_t condattr;
+    pthread_condattr_init( &condattr);
+    pthread_condattr_setclock( &condattr, CLOCK_MONOTONIC);
+
+    if ((result = pthread_cond_init(&new_device->cond, &condattr)) != EOK) {
         pthread_mutex_destroy(&new_device->mutex);
 
         log_err("create_device_session pthread_cond_init failed: %d\n",


### PR DESCRIPTION
There seems to be a deadlock issue with the mutex and/or cond_var setup in netif_stop_queue(). The issue could be in combination to how the Linux drivers callback the synchronisation functions also. The issue presents itself when very high transmission rate is applied under non-realistic test conditions. It is suspected the synchronisation functions of the transmission function netif_tx() is problematic. The symptom is the loss of receive ability when this deadlock happens. Fix includes:
- Refactor of netif_tx() and synchronisation interface functions netif_start_queue(), netif_queue_stopped(), netif_wake_queue() and netif_stop_queue().
- Implementation of queue fault recovery by replacing pthread_cond_wait() with pthread_cond_timedwait() with timeout handling.
  * netif transmission queue fault recovery.
  * queue dequeue() function fault recovery.