### PR TITLE
Fix for bug https://github.com/Deniz-Eren/dev-can-linux/issues/56

### DIFF
--- a/src/include/resmgr.h
+++ b/src/include/resmgr.h
@@ -113,7 +113,6 @@ typedef struct can_ocb {
     client_session_t *session;
 
     struct rx_t {
-        pthread_attr_t thread_attr;
         pthread_t thread;
         pthread_mutex_t mutex;
         pthread_cond_t cond;

--- a/src/resmgr.c
+++ b/src/resmgr.c
@@ -564,12 +564,7 @@ IOFUNC_OCB_T* can_ocb_calloc (resmgr_context_t* ctp, IOFUNC_ATTR_T* attr) {
             return NULL;
         }
 
-        pthread_attr_init(&ocb->rx.thread_attr);
-        pthread_attr_setdetachstate(
-                &ocb->rx.thread_attr, PTHREAD_CREATE_DETACHED );
-
-        pthread_create( &ocb->rx.thread, &ocb->rx.thread_attr,
-                &rx_loop, ocb );
+        pthread_create(&ocb->rx.thread, NULL, &rx_loop, ocb);
     }
 
     return ocb;
@@ -658,7 +653,7 @@ void* rx_loop (void* arg) {
     {
         log_err("rx_loop exit: Unable to attach to channel.\n");
 
-        return NULL;
+        pthread_exit(NULL);
     }
 
     while (1) {
@@ -676,6 +671,7 @@ void* rx_loop (void* arg) {
         if (resmgr->shutdown || (ocb->rx.queue == NULL)) {
             log_trace("rx_loop exit\n");
 
+            ConnectDetach(coid);
             pthread_exit(NULL);
         }
 

--- a/tests/driver/io/driver-io-tests.cpp
+++ b/tests/driver/io/driver-io-tests.cpp
@@ -397,3 +397,238 @@ TEST( IO, SingleSendMultiReceive ) {
 
     close(fd);
 }
+
+TEST( IO, SingleSendReceiveAfterManyOpenClose ) {
+    // First open and close the file descriptors many times
+    const int many = 100000;
+
+    for (int k = 0; k < many; ++k) {
+        // Open both tx and rx channels of both devices
+        int fd0rx = open(get_device0_rx0().c_str(), O_RDWR);
+        int fd0tx = open(get_device0_tx0().c_str(), O_RDWR);
+
+        EXPECT_NE(fd0rx, -1);
+        EXPECT_NE(fd0tx, -1);
+
+        int fd1tx = -1;
+        int fd1rx = -1;
+
+        if (get_device1_tx0() != std::string("")) {
+            fd1rx = open(get_device1_rx0().c_str(), O_RDWR);
+            fd1tx = open(get_device1_tx0().c_str(), O_RDWR);
+
+            EXPECT_NE(fd1rx, -1);
+            EXPECT_NE(fd1tx, -1);
+        }
+
+        // Close both tx and rx channels of both devices
+
+        if (fd0rx != -1) {
+            close(fd0rx);
+        }
+
+        if (fd0tx != -1) {
+            close(fd0tx);
+        }
+
+        if (fd1rx != -1) {
+            close(fd1rx);
+        }
+
+        if (fd1tx != -1) {
+            close(fd1tx);
+        }
+    }
+
+    int fd0 = open(get_device0_tx0().c_str(), O_RDWR);
+
+    EXPECT_NE(fd0, -1);
+
+    int fd1 = -1;
+
+    if (get_device1_tx0() != std::string("")) {
+        fd1 = open(get_device1_tx0().c_str(), O_RDWR);
+
+        EXPECT_NE(fd1, -1);
+    }
+
+    char msg[] = "test message";
+    char wrong_msg[] = "wrong message";
+
+    uint32_t mid = 0xABC;
+    uint32_t wrong_mid = 0xAB1;
+
+    char msg0[16], msg1[16];
+
+    receive_loop0_started = receive_loop1_started = false;
+
+    pthread_t thread0;
+    pthread_create(&thread0, NULL, &receive_loop0, msg0);
+
+    pthread_t thread1;
+
+    if (fd1 != -1) {
+        pthread_create(&thread1, NULL, &receive_loop1, msg1);
+    }
+
+    while (!receive_loop0_started) {
+        usleep(1000);
+    }
+
+    if (fd1 != -1) {
+        while (!receive_loop1_started) {
+            usleep(1000);
+        }
+    }
+
+    struct can_devctl_stats stats0, stats1;
+
+    int get_stats_ret = get_stats(fd0, &stats0);
+
+    EXPECT_EQ(get_stats_ret, EOK);
+
+    uint32_t initial_tx_frames0 = stats0.transmitted_frames;
+    uint32_t initial_rx_frames0 = stats0.received_frames;
+    uint32_t initial_missing_ack0 = stats0.missing_ack;
+    uint32_t initial_total_frame_errors0 = stats0.total_frame_errors;
+    uint32_t initial_hw_receive_overflows0 = stats0.hw_receive_overflows;
+    uint32_t initial_rx_interrupts0 = stats0.rx_interrupts;
+    uint32_t initial_tx_interrupts0 = stats0.tx_interrupts;
+    uint32_t initial_total_interrupts0 = stats0.total_interrupts;
+
+    uint32_t initial_tx_frames1 = 0;
+    uint32_t initial_rx_frames1 = 0;
+    uint32_t initial_missing_ack1 = 0;
+    uint32_t initial_total_frame_errors1 = 0;
+    uint32_t initial_hw_receive_overflows1 = 0;
+    uint32_t initial_rx_interrupts1 = 0;
+    uint32_t initial_tx_interrupts1 = 0;
+    uint32_t initial_total_interrupts1 = 0;
+
+    if (fd1 != -1) {
+        get_stats_ret = get_stats(fd1, &stats1);
+
+        EXPECT_EQ(get_stats_ret, EOK);
+
+        initial_tx_frames1 = stats1.transmitted_frames;
+        initial_rx_frames1 = stats1.received_frames;
+        initial_missing_ack1 = stats1.missing_ack;
+        initial_total_frame_errors1 = stats1.total_frame_errors;
+        initial_hw_receive_overflows1 = stats1.hw_receive_overflows;
+        initial_rx_interrupts1 = stats1.rx_interrupts;
+        initial_tx_interrupts1 = stats1.tx_interrupts;
+        initial_total_interrupts1 = stats1.total_interrupts;
+    }
+
+    int set_mid_ret = set_mid(fd0, wrong_mid);
+
+    EXPECT_EQ(set_mid_ret, EOK);
+
+    int n = write(fd0, wrong_msg, 12);
+
+    set_mid_ret = set_mid(fd0, mid);
+
+    EXPECT_EQ(set_mid_ret, EOK);
+
+    n = write(fd0, msg, 12);
+
+    EXPECT_EQ(n, 12);
+
+    void* exit_ptr0;
+    pthread_join(thread0, &exit_ptr0);
+
+    EXPECT_EQ(exit_ptr0, msg0);
+
+    msg0[n] = '\0';
+
+    EXPECT_EQ(std::string(msg0), std::string("test message"));
+
+    usleep(3000);
+
+    if (fd1 != -1) {
+        set_mid_ret = set_mid(fd1, wrong_mid);
+
+        EXPECT_EQ(set_mid_ret, EOK);
+
+        n = write(fd1, wrong_msg, 12);
+
+        set_mid_ret = set_mid(fd1, mid);
+
+        EXPECT_EQ(set_mid_ret, EOK);
+
+        n = write(fd1, msg, 12);
+
+        EXPECT_EQ(n, 12);
+
+        void* exit_ptr1;
+        pthread_join(thread1, &exit_ptr1);
+
+        EXPECT_EQ(exit_ptr1, msg1);
+
+        msg1[n] = '\0';
+
+        EXPECT_EQ(std::string(msg1), std::string("test message"));
+    }
+
+    get_stats_ret = get_stats(fd0, &stats0);
+
+    EXPECT_EQ(get_stats_ret, EOK);
+
+    if (fd1 != -1) {
+        get_stats_ret = get_stats(fd1, &stats1);
+
+        EXPECT_EQ(get_stats_ret, EOK);
+    }
+
+    EXPECT_EQ(stats0.transmitted_frames - initial_tx_frames0, 4);
+    EXPECT_EQ(stats0.received_frames - initial_rx_frames0, 0);
+    EXPECT_EQ(stats0.missing_ack - initial_missing_ack0, 0);
+    EXPECT_EQ(stats0.total_frame_errors - initial_total_frame_errors0, 0);
+    EXPECT_EQ(stats0.hw_receive_overflows - initial_hw_receive_overflows0, 0);
+    EXPECT_EQ(stats0.rx_interrupts - initial_rx_interrupts0, 0);
+    EXPECT_EQ(stats0.tx_interrupts - initial_tx_interrupts0, 0);
+    EXPECT_EQ(stats0.total_interrupts - initial_total_interrupts0, 0);
+
+    EXPECT_EQ(stats0.stuff_errors, 0);
+    EXPECT_EQ(stats0.form_errors, 0);
+    EXPECT_EQ(stats0.dom_bit_recess_errors, 0);
+    EXPECT_EQ(stats0.recess_bit_dom_errors, 0);
+    EXPECT_EQ(stats0.parity_errors, 0);
+    EXPECT_EQ(stats0.crc_errors, 0);
+    EXPECT_EQ(stats0.sw_receive_q_full, 0);
+    EXPECT_EQ(stats0.error_warning_state_count, 0);
+    EXPECT_EQ(stats0.error_passive_state_count, 0);
+    EXPECT_EQ(stats0.bus_off_state_count, 0);
+    EXPECT_EQ(stats0.bus_idle_count, 0);
+    EXPECT_EQ(stats0.power_down_count, 0);
+    EXPECT_EQ(stats0.wake_up_count, 0);
+
+    close(fd0);
+
+    if (fd1 != -1) {
+        EXPECT_EQ(stats1.transmitted_frames - initial_tx_frames1, 4);
+        EXPECT_EQ(stats1.received_frames - initial_rx_frames1, 0);
+        EXPECT_EQ(stats1.missing_ack - initial_missing_ack1, 0);
+        EXPECT_EQ(stats1.total_frame_errors - initial_total_frame_errors1, 0);
+        EXPECT_EQ(stats1.hw_receive_overflows - initial_hw_receive_overflows1, 0);
+        EXPECT_EQ(stats1.rx_interrupts - initial_rx_interrupts1, 0);
+        EXPECT_EQ(stats1.tx_interrupts - initial_tx_interrupts1, 0);
+        EXPECT_EQ(stats1.total_interrupts - initial_total_interrupts1, 0);
+
+        EXPECT_EQ(stats1.stuff_errors, 0);
+        EXPECT_EQ(stats1.form_errors, 0);
+        EXPECT_EQ(stats1.dom_bit_recess_errors, 0);
+        EXPECT_EQ(stats1.recess_bit_dom_errors, 0);
+        EXPECT_EQ(stats1.parity_errors, 0);
+        EXPECT_EQ(stats1.crc_errors, 0);
+        EXPECT_EQ(stats1.sw_receive_q_full, 0);
+        EXPECT_EQ(stats1.error_warning_state_count, 0);
+        EXPECT_EQ(stats1.error_passive_state_count, 0);
+        EXPECT_EQ(stats1.bus_off_state_count, 0);
+        EXPECT_EQ(stats1.bus_idle_count, 0);
+        EXPECT_EQ(stats1.power_down_count, 0);
+        EXPECT_EQ(stats1.wake_up_count, 0);
+
+        close(fd1);
+    }
+}


### PR DESCRIPTION
No specific or hardcoded limits of 65536 or 2^16 exist in the code base.

Initial suspicion was that open/close results in a client session being created and destroyed. Client sessions have with them an RX thread per connection client (via open) to deliver the received messages. The QNX OS limit of maximum number of threads per process is known to be 32767, so we investigated whether the threads were not being cleaned up properly. This wasn't the case however, and all the threads created are detached and cleanly shutdown.

To further test this theory an experiment was done. Driver dev-can-linux was started and while monitoring the number of threads active using command "pidin -p pid" messages were sent using command "cansend -u0,tx0 -m0x1234,1,0xABCD". No increase in the number of threads noted.

Next to replicate the example code given in https://github.com/Deniz-Eren/dev-can-linux/issues/57, i.e. "void *fctThreadCan3( void *arg )", we wrote a new unit test SingleSendReceiveAfterManyOpenClose in tests/driver/io/driver-io-tests.cpp to perform the same test as test SingleSendReceive but only after opening and closing the file descriptors 100,000 times.

Exact problem described in https://github.com/Deniz-Eren/dev-can-linux/issues/56 was successfully replicated by test SingleSendReceiveAfterManyOpenClose. After running the test the command "candump -u0,rx0" no longer recieves messages from command "cansend -u0,tx0 -m0x1234,1,0xABCD".

The error message "rx_loop exit: Unable to attach to channel." was noted during the test produced from https://github.com/Deniz-Eren/dev-can-linux/blob/1bb3cfede13e847c98a309da3b5fbc415c4694ce/src/resmgr.c#L656

The problem was identified to be in rx_loop whereby the message_connect() was never being disconnected. After adding the correct disconnection the problem is shown to be fixed.

Further improvements added by making the rx_loop thread non-detached so that on close we can pthread_join() to clean-up smoother.