### PR TITLE
Support module parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Options:
                      # (Special cases only) Forced btr* baud-rate setting method:
                      dev-can-linux -b id=0,freq=125k,btr0=0x07,btr1=0x14
 
+    -m subopts - Kernel module parameters
+
+                 Suboptions (subopts):
+
+                 f81601_ex_clk=#    - Driver f81601 external clock
+                                      If not specified the driver will use
+                                      internal clock.
+
     -E         - Enable internal loopback (echo TX to RX of each device)
     -w         - Print warranty message and exit.
     -c         - Print license details and exit.

--- a/src/config.c
+++ b/src/config.c
@@ -60,6 +60,7 @@ int opts = 0;
 int optt = 0;
 int optu = 0;
 int optb = 0;
+int optm = 0;
 int optx = 0;
 int optE = 0;
 

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -57,6 +57,7 @@ extern int opts;
 extern int optt;
 extern int optu;
 extern int optb;
+extern int optm;
 extern int optx;
 extern int optE;
 
@@ -94,6 +95,12 @@ extern size_t num_disable_device_configs;
 extern device_config_t* disable_device_config;
 extern size_t num_enable_device_cap_configs;
 extern device_config_t* enable_device_cap_config;
+
+/*
+ * Kernel module_param() variables of various drivers
+ */
+extern bool internal_clk;           // drivers/net/can/sja1000/f81601.c
+extern unsigned int external_clk;   // "
 
 
 /*

--- a/src/kernel/drivers/net/can/sja1000/f81601.c
+++ b/src/kernel/drivers/net/can/sja1000/f81601.c
@@ -71,11 +71,11 @@ static const struct pci_device_id f81601_pci_tbl[] = {
 
 MODULE_DEVICE_TABLE(pci, f81601_pci_tbl);
 
-static bool internal_clk = true;
+/*static */bool internal_clk = true;
 module_param(internal_clk, bool, 0444);
 MODULE_PARM_DESC(internal_clk, "Use internal clock, default true (24MHz)");
 
-static unsigned int external_clk;
+/*static */unsigned int external_clk;
 module_param(external_clk, uint, 0444);
 MODULE_PARM_DESC(external_clk, "External clock when internal_clk disabled");
 

--- a/src/prints.c
+++ b/src/prints.c
@@ -161,6 +161,14 @@ void print_help (char* program_name) {
     printf("                     # (Special cases only) Forced btr* baud-rate setting method:\n");
     printf("                     \e[1mdev-can-linux -b id=0,freq=125k,btr0=0x07,btr1=0x14\e[m\n");
     printf("\n");
+    printf("    \e[1m-m subopts\e[m - Kernel module parameters\n");
+    printf("\n");
+    printf("                 Suboptions (\e[1msubopts\e[m):\n");
+    printf("\n");
+    printf("                 \e[1mf81601_ex_clk=#\e[m    - Driver f81601 external clock\n");
+    printf("                                      If not specified the driver will use\n");
+    printf("                                      internal clock.\n");
+    printf("\n");
     printf("    \e[1m-E\e[m         - Enable internal loopback (echo TX to RX of each device)\n");
     printf("    \e[1m-w\e[m         - Print warranty message and exit.\n");
     printf("    \e[1m-c\e[m         - Print license details and exit.\n");


### PR DESCRIPTION
- Option -m added to manage kernel module parameters.
- Implemented external_clk configuration of driver drivers/net/can/sja1000/f81601.
- Fixed a logging issue that can happen only during the parsing of command-line arguments.
- Reworded some error messages to be more helpful.